### PR TITLE
Perform Climb Sequence with Gyro Offset

### DIFF
--- a/.wpilib/wpilib_preferences.json
+++ b/.wpilib/wpilib_preferences.json
@@ -2,5 +2,5 @@
     "enableCppIntellisense": false,
     "currentLanguage": "java",
     "projectYear": "2022",
-    "teamNumber": 1678
+    "teamNumber": 7678
 }

--- a/src/main/java/com/team1678/frc2022/subsystems/Superstructure.java
+++ b/src/main/java/com/team1678/frc2022/subsystems/Superstructure.java
@@ -263,7 +263,7 @@ public class Superstructure extends Subsystem {
         if (mClimbMode) {
 
             // update gyro offset
-            mGyroOffset = mSwerve.getRoll().getDegrees();
+            mGyroOffset = mSwerve.getRoll().getDegrees() - mStartingGyroPosition;
 
             /*** CLIMB MODE CONTROLS ***/
 


### PR DESCRIPTION
- uses offset for swerve roll from a starting gyro position at the extension for the climb
- ensures that we don't fail the climb due to tilt angles from driving up on the bar
- remediates practice match climb fall at CAPH
- tested for different horizontal and tilt offsets from the bar at arm contact