### PR TITLE
Deadband fix

### DIFF
--- a/src/main/java/com/team1678/frc2022/controlboard/ControlBoard.java
+++ b/src/main/java/com/team1678/frc2022/controlboard/ControlBoard.java
@@ -78,7 +78,10 @@ public class ControlBoard {
         if (Math.abs(tAxes.norm()) < kSwerveDeadband) {
             return new Translation2d();
         } else {
-            return Translation2d.fromPolar(new Rotation2d(tAxes.x(), tAxes.y(), true), (tAxes.norm() - kSwerveDeadband) / (1.0 - kSwerveDeadband));
+            return Translation2d.fromPolar(
+                new Rotation2d(tAxes.x(), tAxes.y(), true),
+                tAxes.norm() >= kSwerveDeadband ? (tAxes.norm() - kSwerveDeadband) / (1.0 - kSwerveDeadband) : 0.0
+            );
         }
     }
 

--- a/src/main/java/com/team1678/frc2022/controlboard/ControlBoard.java
+++ b/src/main/java/com/team1678/frc2022/controlboard/ControlBoard.java
@@ -78,12 +78,7 @@ public class ControlBoard {
         if (Math.abs(tAxes.norm()) < kSwerveDeadband) {
             return new Translation2d();
         } else {
-            Rotation2d deadband_direction = new Rotation2d(tAxes.x(), tAxes.y(), true);
-            Translation2d deadband_vector = Translation2d.fromPolar(deadband_direction, kSwerveDeadband);
-
-            double scaled_x = tAxes.x() - (deadband_vector.x()) / (1 - deadband_vector.x());
-            double scaled_y = tAxes.y() - (deadband_vector.y()) / (1 - deadband_vector.y());
-            return new Translation2d(scaled_x, scaled_y).scale(Constants.SwerveConstants.maxSpeed);
+            return Translation2d.fromPolar(new Rotation2d(tAxes.x(), tAxes.y(), true), (tAxes.norm() - kSwerveDeadband) / (1.0 - kSwerveDeadband));
         }
     }
 


### PR DESCRIPTION
I was looking through and noticed the controller scaling seemed a little off, so I tested it in desmos and found that it doesn't reach full input. The proposed change to the scaling hits 0 at the deadband and 1 at full input. It's a small change but with the current scaling the driver can only reach about 82% of the full input, which can be very significant.

The desmos document I modeled this in is linked [here](https://www.desmos.com/calculator/p64o6t7pgv).

I didn't bother with any atan2 stuff in the desmos so it just has to stay in the right side. You don't have to adjust any of the values on the left directly, just drag the blue point on the graph.